### PR TITLE
Explicitly declare `children` prop for `AuthProvider` component

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,8 @@ import { BaseAuthClient } from './types';
  * Props that can be passed to AuthProvider
  */
 export type AuthProviderProps = {
+  children?: React.ReactNode;
+
   /**
    * An optional component to display if AuthClient initialization failed.
    */


### PR DESCRIPTION
This PR fixes an issue when using this library with React 18 and Typescript due to breaking changes introduced in `@types/react@^18.0.0`

See [React 18 Upgrade guide](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions) and [React 18 typings pull request](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210) for more details

Fixes #1